### PR TITLE
fix buff executable, and allow post method to use options hash

### DIFF
--- a/bin/buff
+++ b/bin/buff
@@ -7,11 +7,19 @@ require 'buff'
 begin
   require 'yaml'
 
+  rc_file_path = File.expand_path('~/.bufferapprc')
+  raise Errno::ENOENT unless File.exists?(rc_file_path)
+
   options = YAML.load_file(File.expand_path('~/.bufferapprc'))
   if options.class == String
-    options['access_token'], options['profile_index'] = options.split
+    options_str = options.dup
+    options = Hash.new
+    options['access_token'], options['profile_index'] = options_str.split
     options['verion'] = '0.0.0'
   end
+rescue Errno::ENOENT
+  puts "You're missing the ~/.bufferapprc file. See the README for info."
+  exit 1
 rescue
   puts "Please upgrade from older config file structure" if ENV['BUFF_DEBUG']
 end
@@ -19,5 +27,5 @@ end
 client = Buff::Client.new(options['access_token'])
 id = client.profiles[options['profile_index'].to_i].id
 
-response = client.create_update(body: {text: ARGV.join(" "), profile_ids: [ id ] } )
+response = client.create_update(body: {text: ARGV.join(" "), profile_ids: [ id ] })
 puts response if ENV['BUFF_DEBUG']

--- a/lib/buff/core.rb
+++ b/lib/buff/core.rb
@@ -29,6 +29,7 @@ module Buff
 
       def post(path, options = {})
         params = merge_auth_token_and_query(options)
+        params.merge!(options)
         response = @connection.post do |req|
           req.url path.remove_leading_slash
           req.headers['Content-Type'] = "application/x-www-form-urlencoded"


### PR DESCRIPTION
Hi -- this is a small patch to Buff that fixes two problems I encountered. 1- the executable had code that didn't work, because of an attempt to use a string as an implicit hash, and 2- I couldn't pass update options like "now: true" and have them passed to the API endpoint, because the "post" method was ignoring them. Thanks for considering this!
