### PR TITLE
Fix rash dependency

### DIFF
--- a/buff.gemspec
+++ b/buff.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'yajl-ruby'
   gem.add_runtime_dependency 'faraday_middleware'
   gem.add_runtime_dependency 'faraday'
-  gem.add_runtime_dependency 'rash'
+  gem.add_runtime_dependency 'hashie'
   gem.add_runtime_dependency 'rake'
   gem.add_runtime_dependency 'addressable'
 end

--- a/lib/buff.rb
+++ b/lib/buff.rb
@@ -1,7 +1,7 @@
 require "faraday_middleware"
 require "faraday"
 require "json"
-require "rash"
+require "hashie/mash"
 require "addressable/uri"
 
 require_relative "buff/version"


### PR DESCRIPTION
`rash.gem` depends on hashie <= 2, and this is troublesome.

Please merge this and bump the version!
