### PR TITLE
ARGF does not have a chomp method

### DIFF
--- a/bin/buffer
+++ b/bin/buffer
@@ -27,5 +27,7 @@ end
 client = Buffer::Client.new(options['access_token'])
 id = client.profiles[options['profile_index'].to_i].id
 
-response = client.create_update(body: {text: ARGF.chomp, profile_ids: [ id ] } )
-puts response if ENV['BUFF_DEBUG']
+ARGF.each_line do |line|
+  response = client.create_update(body: {text: line.chomp, profile_ids: [ id ] } )
+  puts response if ENV['BUFF_DEBUG']
+end


### PR DESCRIPTION
You probably meant to cycle through the lines and chomp each.

I'm using Ruby-2.2.0; it's possible that an older version of Ruby supported ARGF#chomp