### PR TITLE
Fix http error handling

### DIFF
--- a/lib/buffer/core.rb
+++ b/lib/buffer/core.rb
@@ -57,11 +57,11 @@ module Buffer
       end
 
       def handle_response_code(response)
-        error = Hashie::Mash.new(response.body)
-        raise Buffer::Error::APIError unless error.code
-        "Buffer API Error Code: #{error.code}\n" +
-        "HTTP Code: #{response.code}." +
-        "Description: #{error.error}"
+        error = Hashie::Mash.new(JSON.parse(response.body))
+        raise Buffer::Error::APIError,
+          "Buffer API Error Code: #{error.code} " +
+          "HTTP Code: #{response.status}. " +
+          "Description: #{error.error}"
       end
     end
   end


### PR DESCRIPTION
Right now, hashie can't manage the error, since it's waiting for an hash, and `response.body` is a string.
This fix by @pcreux should fix the issue.